### PR TITLE
Improve button focus outline

### DIFF
--- a/allOf.jst
+++ b/allOf.jst
@@ -1,0 +1,32 @@
+{{# def.definitions }}
+{{# def.errors }}
+{{# def.setupKeyword }}
+{{# def.setupNextLevel }}
+
+{{
+  var $currentBaseId = $it.baseId
+    , $allSchemasEmpty = true;
+}}
+
+{{~ $schema:$sch:$i }}
+  {{? {{# def.nonEmptySchema:$sch }} }}
+    {{
+      $allSchemasEmpty = false;
+      $it.schema = $sch;
+      $it.schemaPath = $schemaPath + '[' + $i + ']';
+      $it.errSchemaPath = $errSchemaPath + '/' + $i;
+    }}
+
+    {{# def.insertSubschemaCode }}
+
+    {{# def.ifResultValid }}
+  {{?}}
+{{~}}
+
+{{? $breakOnError }}
+  {{? $allSchemasEmpty }}
+    if (true) {
+  {{??}}
+    {{= $closingBraces.slice(0,-1) }}
+  {{?}}
+{{?}}


### PR DESCRIPTION
Replace current box-shadow focus styles with a 2px high-contrast outline to improve keyboard accessibility and visibility. The change updates :focus-visible rules and adjusts spacing to avoid outline overlap with button borders.