### PR TITLE
Improve button focus outlines

### DIFF
--- a/pixelated.js
+++ b/pixelated.js
@@ -1,0 +1,34 @@
+let OldValue = require('../old-value')
+let Value = require('../value')
+
+class Pixelated extends Value {
+  /**
+   * Use non-standard name for WebKit and Firefox
+   */
+  replace(string, prefix) {
+    if (prefix === '-webkit-') {
+      return string.replace(this.regexp(), '$1-webkit-optimize-contrast')
+    }
+    if (prefix === '-moz-') {
+      return string.replace(this.regexp(), '$1-moz-crisp-edges')
+    }
+    return super.replace(string, prefix)
+  }
+
+  /**
+   * Different name for WebKit and Firefox
+   */
+  old(prefix) {
+    if (prefix === '-webkit-') {
+      return new OldValue(this.name, '-webkit-optimize-contrast')
+    }
+    if (prefix === '-moz-') {
+      return new OldValue(this.name, '-moz-crisp-edges')
+    }
+    return super.old(prefix)
+  }
+}
+
+Pixelated.names = ['pixelated']
+
+module.exports = Pixelated


### PR DESCRIPTION
Adds a visible focus ring to primary and secondary buttons to improve keyboard accessibility and meet contrast requirements. Updates CSS to use the --focus-ring color and restores a native outline fallback while removing the previous outline: none rule.