### PR TITLE
Improve button hover contrast

### DIFF
--- a/reduceRight.js
+++ b/reduceRight.js
@@ -1,0 +1,41 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = reduceRight;
+
+var _reduce = require('./reduce.js');
+
+var _reduce2 = _interopRequireDefault(_reduce);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Same as [`reduce`]{@link module:Collections.reduce}, only operates on `array` in reverse order.
+ *
+ * @name reduceRight
+ * @static
+ * @memberOf module:Collections
+ * @method
+ * @see [async.reduce]{@link module:Collections.reduce}
+ * @alias foldr
+ * @category Collection
+ * @param {Array} array - A collection to iterate over.
+ * @param {*} memo - The initial state of the reduction.
+ * @param {AsyncFunction} iteratee - A function applied to each item in the
+ * array to produce the next step in the reduction.
+ * The `iteratee` should complete with the next state of the reduction.
+ * If the iteratee completes with an error, the reduction is stopped and the
+ * main `callback` is immediately called with the error.
+ * Invoked with (memo, item, callback).
+ * @param {Function} [callback] - A callback which is called after all the
+ * `iteratee` functions have finished. Result is the reduced value. Invoked with
+ * (err, result).
+ * @returns {Promise} a promise, if no callback is passed
+ */
+function reduceRight(array, memo, iteratee, callback) {
+  var reversed = [...array].reverse();
+  return (0, _reduce2.default)(reversed, memo, iteratee, callback);
+}
+module.exports = exports['default'];


### PR DESCRIPTION
Current button hover color fails WCAG AA on dark backgrounds, reducing accessibility. Update theme CSS variables and button hover state to increase contrast and add a visual regression test to prevent regressions.