### PR TITLE
Debounce search input requests

### DIFF
--- a/restore-with-components.js
+++ b/restore-with-components.js
@@ -1,0 +1,12 @@
+var configuration = require('../configuration');
+
+function restoreWithComponents(property) {
+  var descriptor = configuration[property.name];
+
+  if (descriptor && descriptor.shorthand) {
+    return descriptor.restore(property, configuration);
+  }
+  return property.value;
+}
+
+module.exports = restoreWithComponents;


### PR DESCRIPTION
This change debounces the global search input to reduce API calls and UI flicker when users type quickly. It adds a 300ms debounce in SearchBar.tsx, updates the search hook to respect cancellation, and adjusts unit tests accordingly.